### PR TITLE
add link to naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a template to create a new repository for the GLAM Workbench.
 ### Create a repository from this template
 
 1. Click the big green **Use this template** button.
-2. Enter a name for your new repository and click **Create repository from template**
+2. Enter [a name for your new repository](https://glam-workbench.net/get-involved/developing-repositories/#think-of-a-name) and click **Create repository from template**
 3. Head over to the created repository and complete the setup.
 
 ### Configure authentication


### PR DESCRIPTION
Add a link back to the GLAM workbench page describing the conventions for Docker repo names. This is required because if the naming convention is not followed, new Github workbenches can be "created" but the Docker commands may fail.