### PR TITLE
Keep user metadata around after cookiecutter setup.

### DIFF
--- a/.github/workflows/setup-repository.yml
+++ b/.github/workflows/setup-repository.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Prepare root directory
         shell: bash
-        # Remove all files and folder exepct .git/ and cookiecutter-temp/
+        # Remove all files and folder except .git/, cookiecutter-temp/, and metadata.json
         run: |
           find ./ -maxdepth 1 \
           ! -name '.git' \

--- a/.github/workflows/setup-repository.yml
+++ b/.github/workflows/setup-repository.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          # Comminting workflow files using the regular GITHUB_TOKEN will fail with 
+          # Comminting workflow files using the regular GITHUB_TOKEN will fail with
           # `Git Error: Refusing to allow a GitHub App to create or update workflow without workflows permission`.
           # This is by design to prevent third-parties from adding malicious workflow files.
           #
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install dependencies
         run: pip install cookiecutter
@@ -52,6 +52,10 @@ jobs:
         # --output-dir    Where to output the generated project dir into
         run: cookiecutter . --no-input repository=${{ github.repository }} repository_name=${{ github.event.repository.name }} temp_directory=cookiecutter-temp
 
+      - name: Generate metadata
+        run: |
+          python extract_metadata.py
+
       - name: Prepare root directory
         shell: bash
         # Remove all files and folder exepct .git/ and cookiecutter-temp/
@@ -59,6 +63,7 @@ jobs:
           find ./ -maxdepth 1 \
           ! -name '.git' \
           ! -name 'cookiecutter-temp' \
+          ! -name 'metadata.json' \
           ! -name '.' \
           ! -exec rm -rf {} +
 

--- a/extract_metadata.py
+++ b/extract_metadata.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+INPUT_FILE = "cookiecutter.json"
+OUTPUT_FILE = "metadata.json"
+FIELDS = {
+    "project_name",
+    "project_description",
+    "creators",
+}
+
+
+def main():
+    metadata = extract_metadata(INPUT_FILE)
+    with open(OUTPUT_FILE, "w") as output_file:
+        output_file.write(json.dumps(metadata))
+
+
+def extract_metadata(file: Path) -> Dict[str, Any]:
+    with open(file) as info:
+        data: Dict[str, Any] = json.load(info)
+        result = {k: v for (k, v) in data.items() if k in FIELDS}
+    return result
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Uses a python script to extract fields from `cookiecutter.json` into a new file called `metadata.json`.
- Modifies the github action workflow to keep this `metadata.json` file after cookiecutter runs. 